### PR TITLE
Add build-only job for both feature branch and master

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,13 +1,34 @@
 name: github pages
 
 on:
+  pull_request:
+    branches:
+      - '*'
+      - '!master'
   push:
     branches:
       - master
 
 jobs:
+  build:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true  # Fetch Hugo themes
+          fetch-depth: 0   
+
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: '0.68.3'
+
+      - name: Build
+        run: hugo --minify
+
   deploy:
     runs-on: ubuntu-18.04
+    if: {{github.ref == 'refs/heads/master'}}
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -24,7 +24,7 @@ jobs:
 
   deploy:
     runs-on: ubuntu-18.04
-    if: {{github.ref == 'refs/heads/master'}}
+    if: github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,13 +1,9 @@
 name: github pages
 
 on:
-  pull_request:
-    branches:
-      - '*'
-      - '!master'
   push:
     branches:
-      - master
+      - '*'
 
 jobs:
   build:


### PR DESCRIPTION
This should : 
- run the build job when pushing to a feature branch and master branch
- only run the deploy on master branch with condition `if: github.ref == 'refs/heads/master'` in the deploy job
(see here for reference https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idif)

we can add more job to do some testing or linter job later (if necessary) for the feature branch by using the if condition 